### PR TITLE
feat: 관리자가 모든 보고서 페이지에서 편집 가능하도록 기능 추가

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -913,6 +913,8 @@ export default function HomePage() {
           <div className="container mx-auto px-4 py-2 pb-20">
             <ReportList
               onReportClick={handleReportSelect}
+              isAdmin={!!session}
+              onEdit={handleEditReportFromViewer}
             />
           </div>
         </div>
@@ -942,21 +944,33 @@ export default function HomePage() {
         {/* Monthly reports page */}
         <div className={`${getPageClasses("monthly-reports", currentView)} bg-pattern-grid`}>
           <div className="container mx-auto px-4 py-2 pb-20">
-            <MonthlyReports onReportClick={handleMonthlyReportSelect} />
+            <MonthlyReports
+              onReportClick={handleMonthlyReportSelect}
+              isAdmin={!!session}
+              onEdit={handleEditReportFromViewer}
+            />
           </div>
         </div>
 
         {/* Organization reports page */}
         <div className={`${getPageClasses("organization-reports", currentView)} bg-pattern-circuit`}>
           <div className="container mx-auto px-4 py-2 pb-20">
-            <OrganizationReports onReportClick={handleOrganizationReportSelect} />
+            <OrganizationReports
+              onReportClick={handleOrganizationReportSelect}
+              isAdmin={!!session}
+              onEdit={handleEditReportFromViewer}
+            />
           </div>
         </div>
 
         {/* Category reports page */}
         <div className={`${getPageClasses("category-reports", currentView)} bg-pattern-constellation`}>
           <div className="container mx-auto px-4 py-2 pb-20">
-            <CategoryReports onReportClick={handleCategoryReportSelect} />
+            <CategoryReports
+              onReportClick={handleCategoryReportSelect}
+              isAdmin={!!session}
+              onEdit={handleEditReportFromViewer}
+            />
           </div>
         </div>
 

--- a/components/category-reports.tsx
+++ b/components/category-reports.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import React from "react"
-import { Tag as TagIcon, Calendar } from "lucide-react"
+import { Tag as TagIcon, Calendar, Edit } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { GroupedReports } from "@/components/grouped-reports"
 
 interface CategoryStats {
@@ -13,9 +14,11 @@ interface CategoryStats {
 
 interface CategoryReportsProps {
   onReportClick: (report: any) => void
+  isAdmin?: boolean
+  onEdit?: (report: any) => void
 }
 
-export function CategoryReports({ onReportClick }: CategoryReportsProps) {
+export function CategoryReports({ onReportClick, isAdmin = false, onEdit }: CategoryReportsProps) {
   return (
     <GroupedReports<CategoryStats>
       title="분야별 표준화 동향"
@@ -27,6 +30,8 @@ export function CategoryReports({ onReportClick }: CategoryReportsProps) {
       getCount={(s) => s.count}
       buildReportsUrl={(s) => `/api/reports/by-category/${encodeURIComponent(s.name)}`}
       onReportClick={onReportClick}
+      isAdmin={isAdmin}
+      onEdit={onEdit}
       showPagination={true}
       itemsPerPage={6}
       showWordCloud={true}
@@ -43,9 +48,25 @@ export function CategoryReports({ onReportClick }: CategoryReportsProps) {
         >
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between gap-2">
-              <Badge variant="outline" className="text-xs">
-                {report.organization}
-              </Badge>
+              <div className="flex items-center gap-2">
+                <Badge variant="outline" className="text-xs">
+                  {report.organization}
+                </Badge>
+                {isAdmin && onEdit && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onEdit(report)
+                    }}
+                  >
+                    <Edit className="w-3 h-3 mr-1" />
+                    수정
+                  </Button>
+                )}
+              </div>
               <div className="text-xs text-muted-foreground flex items-center gap-1">
                 <Calendar className="w-3 h-3" />
                 {report.date}

--- a/components/grouped-reports.tsx
+++ b/components/grouped-reports.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useState } from "react"
-import { ChevronDown, ChevronUp, Calendar, Tag as TagIcon, ChevronLeft, ChevronRight } from "lucide-react"
+import { ChevronDown, ChevronUp, Calendar, Tag as TagIcon, ChevronLeft, ChevronRight, Edit } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -27,6 +27,8 @@ interface GroupedReportsProps<S extends BaseStat> {
   getCount: (stat: S) => number
   buildReportsUrl: (stat: S) => string
   onReportClick: (report: Report) => void
+  isAdmin?: boolean
+  onEdit?: (report: Report) => void
   limit?: number
   itemsPerPage?: number
   showPagination?: boolean
@@ -50,6 +52,8 @@ export function GroupedReports<S extends BaseStat>(props: GroupedReportsProps<S>
     getCount,
     buildReportsUrl,
     onReportClick,
+    isAdmin = false,
+    onEdit,
     limit,
     itemsPerPage = 6,
     showPagination = true,
@@ -107,9 +111,25 @@ export function GroupedReports<S extends BaseStat>(props: GroupedReportsProps<S>
     >
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-2">
-          <Badge variant="secondary" className="text-xs">
-            {report.category}
-          </Badge>
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary" className="text-xs">
+              {report.category}
+            </Badge>
+            {isAdmin && onEdit && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onEdit(report)
+                }}
+              >
+                <Edit className="w-3 h-3 mr-1" />
+                수정
+              </Button>
+            )}
+          </div>
           <div className="text-xs text-muted-foreground">
             {report.organization}
           </div>

--- a/components/monthly-reports.tsx
+++ b/components/monthly-reports.tsx
@@ -14,9 +14,11 @@ interface MonthlyStats {
 
 interface MonthlyReportsProps {
   onReportClick: (report: any) => void
+  isAdmin?: boolean
+  onEdit?: (report: any) => void
 }
 
-export function MonthlyReports({ onReportClick }: MonthlyReportsProps) {
+export function MonthlyReports({ onReportClick, isAdmin = false, onEdit }: MonthlyReportsProps) {
   const [availableYears, setAvailableYears] = useState<number[]>([])
   const [selectedYear, setSelectedYear] = useState<number | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -91,6 +93,8 @@ export function MonthlyReports({ onReportClick }: MonthlyReportsProps) {
             getCount={(s) => s.count}
             buildReportsUrl={(s) => `/api/reports/by-month/${s.year}/${s.month}`}
             onReportClick={onReportClick}
+            isAdmin={isAdmin}
+            onEdit={onEdit}
             showPagination={true}
             itemsPerPage={6}
             loadingStatsText="월별 통계를 불러오는 중..."

--- a/components/organization-reports.tsx
+++ b/components/organization-reports.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import React from "react"
-import { Building, FileText, Tag as TagIcon } from "lucide-react"
+import { Building, FileText, Tag as TagIcon, Edit } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { GroupedReports } from "@/components/grouped-reports"
 
 interface OrganizationStats {
@@ -12,9 +13,11 @@ interface OrganizationStats {
 
 interface OrganizationReportsProps {
   onReportClick: (report: any) => void
+  isAdmin?: boolean
+  onEdit?: (report: any) => void
 }
 
-export function OrganizationReports({ onReportClick }: OrganizationReportsProps) {
+export function OrganizationReports({ onReportClick, isAdmin = false, onEdit }: OrganizationReportsProps) {
   return (
     <GroupedReports<OrganizationStats>
       title="표준화 기구별 동향 보고서"
@@ -26,6 +29,8 @@ export function OrganizationReports({ onReportClick }: OrganizationReportsProps)
       getCount={(s) => s.count}
       buildReportsUrl={(s) => `/api/reports/by-organization/${encodeURIComponent(s.name)}`}
       onReportClick={onReportClick}
+      isAdmin={isAdmin}
+      onEdit={onEdit}
       showPagination={true}
       itemsPerPage={6}
       loadingStatsText="기구별 통계를 불러오는 중..."
@@ -40,9 +45,25 @@ export function OrganizationReports({ onReportClick }: OrganizationReportsProps)
           onClick={() => onReportClick(report)}
         >
           <div className="flex items-start justify-between mb-2">
-            <h3 className="font-semibold text-lg hover:text-primary transition-colors">
-              {report.title}
-            </h3>
+            <div className="flex items-center gap-2">
+              <h3 className="font-semibold text-lg hover:text-primary transition-colors">
+                {report.title}
+              </h3>
+              {isAdmin && onEdit && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onEdit(report)
+                  }}
+                >
+                  <Edit className="w-3 h-3 mr-1" />
+                  수정
+                </Button>
+              )}
+            </div>
             <Badge variant="outline" className="ml-2 shrink-0">
               {new Date(report.date).toLocaleDateString("ko-KR")}
             </Badge>

--- a/components/report-list.tsx
+++ b/components/report-list.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { Search, Download, Calendar, Tag, ChevronRight, Filter } from "lucide-react"
+import { Search, Download, Calendar, Tag, ChevronRight, Filter, Edit } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -22,9 +22,11 @@ interface Report {
 
 interface ReportListProps {
   onReportClick: (report: Report) => void
+  isAdmin?: boolean
+  onEdit?: (report: Report) => void
 }
 
-export function ReportList({ onReportClick }: ReportListProps) {
+export function ReportList({ onReportClick, isAdmin = false, onEdit }: ReportListProps) {
   const [searchTerm, setSearchTerm] = useState("")
   const [selectedCategory, setSelectedCategory] = useState<string>("all")
   const [selectedOrganization, setSelectedOrganization] = useState<string>("all")
@@ -244,9 +246,25 @@ export function ReportList({ onReportClick }: ReportListProps) {
           >
             <CardHeader className="pb-3">
               <div className="flex items-start justify-between gap-2">
-                <Badge variant="secondary" className="text-xs">
-                  {report.category}
-                </Badge>
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-xs">
+                    {report.category}
+                  </Badge>
+                  {isAdmin && onEdit && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onEdit(report)
+                      }}
+                    >
+                      <Edit className="w-3 h-3 mr-1" />
+                      수정
+                    </Button>
+                  )}
+                </div>
                 <div className="text-xs text-muted-foreground flex items-center gap-1">
                   <Calendar className="w-3 h-3" />
                   {report.date}


### PR DESCRIPTION
관리자 인증 시 모든 보고서 리스트와 상세 페이지에 '수정' 버튼 추가:

**추가된 편집 기능:**
- 보고서 목록 페이지 (ReportList): 각 보고서 카드에 수정 버튼
- 월별 보고서 (MonthlyReports): 월별 그룹 내 수정 버튼
- 기구별 보고서 (OrganizationReports): 기구별 그룹 내 수정 버튼
- 분야별 보고서 (CategoryReports): 분야별 그룹 내 수정 버튼
- 보고서 상세 뷰 (ReportViewer): 상단 헤더에 수정 버튼 (기존)

**구현 내용:**
1. GroupedReports 컴포넌트에 isAdmin, onEdit props 추가
2. DefaultCard에 편집 버튼 추가 (관리자만 표시)
3. 각 보고서 컴포넌트에 isAdmin, onEdit props 전달
4. app/page.tsx에서 모든 보고서 컴포넌트에 session 기반 인증 전달
5. 편집 버튼 클릭 시 handleEditReportFromViewer 호출하여 편집 화면 이동

관리자 로그인 후 어디에서든 보고서 편집 가능